### PR TITLE
fix(palletjack): increase job container memory

### DIFF
--- a/.github/actions/palletjack/deploy/action.yml
+++ b/.github/actions/palletjack/deploy/action.yml
@@ -89,7 +89,7 @@ runs:
         env_vars: |-
           PROJECT_ID=${{ inputs.project_id }}
         flags: |
-          --memory=4G
+          --memory=8G
           --service-account=palletjack-sa@${{ inputs.project_id }}.iam.gserviceaccount.com
           --max-retries=1
           --task-timeout=60m


### PR DESCRIPTION
The job has failed with this error message the past few attempts: The configured memory limit was reached

Monitoring confirmed that the memory was being taxed.

I verified that this would not create any significant increase in costs:
![image](https://github.com/user-attachments/assets/7ecf10f5-679b-4a4d-b748-68cfb5eed382)
